### PR TITLE
Add skeleton code for TDD, introduce Lesson unit tests

### DIFF
--- a/lesson/tests/factories.py
+++ b/lesson/tests/factories.py
@@ -1,0 +1,14 @@
+import datetime as dt
+
+import factory
+
+from lesson.models import Lesson
+
+
+class LessonFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Lesson
+        
+    date = factory.LazyFunction(lambda: dt.datetime.now().date())
+    start = factory.LazyFunction(lambda: dt.datetime.now().time())
+    end = factory.LazyFunction(lambda: (dt.datetime.now() + dt.timedelta(hours=1)).time())

--- a/lesson/tests/test_lesson.py
+++ b/lesson/tests/test_lesson.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+
+from lesson.tests.factories import LessonFactory
+
+
+class TestLessonCase(TestCase):
+    def test_no_creation_overlap_teacher(self):
+        """Test that two lessons can't overlap on time if they have same 
+           teacher
+        """
+        lesson1 = LessonFactory()
+        # To be continued :
+        # Try create two lessons with same teacher that overlap in time : 
+        # second lesson should not be created (raise exception on creation 
+        # or check that condition in LessonRegisterForms to make the form invalid)
+        
+    def test_no_creation_overlap_student(self):
+        """Test that two lessons can't overlap on time if they have same 
+           teacher
+        """
+        lesson1 = LessonFactory()
+        # To be continued :
+        # Try create two lessons with same student that overlap in time : 
+        # second lesson should not be created (raise exception on creation 
+        # or check that condition in LessonRegisterForms to make the form invalid)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = TeacherPlan.settings

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+factory_boy==3.2.0
+pytest-django==4.4.0


### PR DESCRIPTION
Use of https://factoryboy.readthedocs.io/en/stable/ to create objects to test, declare 2 tests.

> pip3 install -r requirements-dev.txt
> pytest
![image](https://user-images.githubusercontent.com/84227/125155027-81c03e80-e15d-11eb-8a1c-5d480805c249.png)

Currently code is failing because LessonFactory is improperly implemented : required _student_ and _teacher_ fields are missing.

I just throw the basis to have a tests setup, if you want to build upon it you should continue that PR yourself by :  
- adding StudentFactory and TeacherFactory
- update LessonFactory code using the two factories above
- you should now have a proper way to build lessons objects for tests and the interesting questions arise. How prevent lessons overlap : is it the role of the form to raise an error if it happens ? or is it the model `save` method responsibility ? or both ?
